### PR TITLE
Update Skia version to 1.68.1

### DIFF
--- a/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/Jellyfin.SkiaSharp.NativeAssets.LinuxArm.nuspec
+++ b/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/Jellyfin.SkiaSharp.NativeAssets.LinuxArm.nuspec
@@ -5,7 +5,7 @@
     <!-- package -->
     <id>Jellyfin.SkiaSharp.NativeAssets.LinuxArm</id>
     <title>Jellyfin.SkiaSharp.NativeAssets.LinuxArm</title>
-    <version>1.68.0</version>
+    <version>1.68.1</version>
     <description>
     This is a Raspbian tools built ARM32+ARM64 native library for SkiaSharp.
     
@@ -29,7 +29,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
 
     <dependencies>
-      <dependency id="SkiaSharp" version="1.68.0" />
+      <dependency id="SkiaSharp" version="1.68.1" />
     </dependencies>
 
   </metadata>

--- a/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/README.md
+++ b/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/README.md
@@ -11,5 +11,5 @@ The 64-bit build runs with `-flax-vector-conversions` so, use at your own risk. 
 
 ## Build (non Debian) (uses docker)
 
-1. `build-in-docker.sh`
+1. `build-in-docker.sh` (on Linux) or `build-in-docker.bat` (on Windows)
 2. `nuget pack`

--- a/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/build-in-docker.bat
+++ b/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/build-in-docker.bat
@@ -1,0 +1,5 @@
+docker build -t libskiasharp-linuxarm .
+mkdir runtimes/linux-arm/native
+mkdir runtimes/linux-arm64/native
+docker run --rm -v "%CD%/runtimes/linux-arm/native:/temp" "libskiasharp-linuxarm" cp /build/skia/out/linux-arm/libSkiaSharp.so /temp/
+docker run --rm -v "%CD%/runtimes/linux-arm64/native:/temp64" "libskiasharp-linuxarm" cp /build/skia/out/linux-arm64/libSkiaSharp.so /temp64/

--- a/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/cross-compile-libSkiaSharp.sh
+++ b/Jellyfin.SkiaSharp.NativeAssets.LinuxArm/cross-compile-libSkiaSharp.sh
@@ -4,7 +4,7 @@ TOOLCHAIN_ARM64=gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu
 
 set -e
 if [ ! -d "skia" ] ; then
-    git clone https://github.com/mono/skia.git -b v1.68.0 --depth 1 skia
+    git clone https://github.com/mono/skia.git -b v1.68.1 --depth 1 skia
 fi
 if [ ! -d "depot_tools" ] ; then
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git --depth 1

--- a/Jellyfin.SkiaSharp.NativeAssets.LinuxMusl/compile-libSkiaSharp.sh
+++ b/Jellyfin.SkiaSharp.NativeAssets.LinuxMusl/compile-libSkiaSharp.sh
@@ -3,7 +3,7 @@
 
 set -e
 if [ ! -d "skia" ] ; then
-    git clone https://github.com/mono/skia.git -b v1.68.0 --depth 1 skia
+    git clone https://github.com/mono/skia.git -b v1.68.1 --depth 1 skia
 fi
 
 cd skia


### PR DESCRIPTION
Please note that the NuGet package still needs to be generated and pushed to nuget.org. This PR is only the easy part :-D

I guess we'll need to wait on @EraYaN 

Fixes #2 